### PR TITLE
More algorithms to find scrap match

### DIFF
--- a/SellMyScrap/Commands/SellAllCommand.cs
+++ b/SellMyScrap/Commands/SellAllCommand.cs
@@ -24,7 +24,10 @@ internal class SellAllCommand : SellCommand
             return terminalNode;
         }
 
-        ScrapToSell scrapToSell = Plugin.Instance.GetScrapToSell(int.MaxValue, onlyUseShipInventory: OnlyUseShipInventory());
+        ScrapToSell scrapToSell = Plugin.Instance.GetScrapToSell(new SellCommandRequest(int.MaxValue)
+        {
+            OnlyUseShipInventory = OnlyUseShipInventory()
+        });
 
         if (scrapToSell.ItemCount == 0)
         {

--- a/SellMyScrap/Commands/SellAmountCommand.cs
+++ b/SellMyScrap/Commands/SellAmountCommand.cs
@@ -1,5 +1,6 @@
 ﻿using com.github.zehsteam.SellMyScrap.Data;
 using com.github.zehsteam.SellMyScrap.Helpers;
+using com.github.zehsteam.SellMyScrap.Helpers.ScrapMatchAlgorithms;
 using com.github.zehsteam.SellMyScrap.Patches;
 using System.Data;
 using System.Text;
@@ -42,7 +43,12 @@ internal class SellAmountCommand : SellCommand
             return TerminalPatch.CreateTerminalNode(GetSellAmountInvalidMessage());
         }
 
-        ScrapToSell scrapToSell = Plugin.Instance.GetScrapToSell(requestedValue, withOvertimeBonus: WithOvertimeBonus(), onlyUseShipInventory: OnlyUseShipInventory());
+        ScrapToSell scrapToSell = Plugin.Instance.GetScrapToSell(new SellCommandRequest(requestedValue)
+        {
+            WithOvertimeBonus = WithOvertimeBonus(),
+            OnlyUseShipInventory = OnlyUseShipInventory(),
+            ScrapMatchAlgorithm = GetScrapMatchAlgorithm()
+        });
 
         if (scrapToSell.ItemCount == 0)
         {

--- a/SellMyScrap/Commands/SellCommand.cs
+++ b/SellMyScrap/Commands/SellCommand.cs
@@ -1,4 +1,5 @@
 ﻿using com.github.zehsteam.SellMyScrap.Dependencies.ShipInventoryProxy;
+using com.github.zehsteam.SellMyScrap.Helpers.ScrapMatchAlgorithms;
 using com.github.zehsteam.SellMyScrap.Patches;
 using com.github.zehsteam.SellMyScrap.ScrapEaters;
 using UnityEngine;
@@ -63,6 +64,16 @@ internal class SellCommand : Command
         if (HasFlag("shipinventory")) return true;
 
         return false;
+    }
+
+    protected BaseScrapMatchAlgorithm GetScrapMatchAlgorithm()
+    {
+        if (TryGetFlagData("a", out int flagIndex))
+        {
+            return BaseScrapMatchAlgorithm.GetAlgorithmByFlag(flagIndex);
+        }
+
+        return BaseScrapMatchAlgorithm.Default;
     }
 
     protected static bool CanUseCommand(out TerminalNode terminalNode)

--- a/SellMyScrap/Commands/SellQuotaCommand.cs
+++ b/SellMyScrap/Commands/SellQuotaCommand.cs
@@ -31,7 +31,11 @@ internal class SellQuotaCommand : SellCommand
             return TerminalPatch.CreateTerminalNode("Quota has already been fulfilled.\n\n");
         }
 
-        ScrapToSell scrapToSell = Plugin.Instance.GetScrapToSell(requestedValue, onlyUseShipInventory: OnlyUseShipInventory());
+        ScrapToSell scrapToSell = Plugin.Instance.GetScrapToSell(new SellCommandRequest(requestedValue)
+        {
+            OnlyUseShipInventory = OnlyUseShipInventory(),
+            ScrapMatchAlgorithm = GetScrapMatchAlgorithm()
+        });
 
         if (scrapToSell.ItemCount == 0)
         {

--- a/SellMyScrap/Data/SellCommandRequest.cs
+++ b/SellMyScrap/Data/SellCommandRequest.cs
@@ -1,0 +1,78 @@
+﻿using com.github.zehsteam.SellMyScrap.Helpers.ScrapMatchAlgorithms;
+using com.github.zehsteam.SellMyScrap.Patches;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace com.github.zehsteam.SellMyScrap.Data
+{
+    /// <summary>
+    /// Scrap sell request with settings from config and flags to choose correct 
+    /// </summary>
+    /// <param name="value">Scrap value the player needs to get from current selling</param>
+    public class SellCommandRequest(int value)
+    {
+        /// <summary>Scrap value the player needs to get from current selling</summary>
+        public int Value => value;
+        /// <summary>
+        /// Whether should sell algorithms include shotguns, ammo, pickles, gift boxes, etc. to <see cref="BaseScrapMatchAlgorithm.items"/><br></br>
+        /// Default: <see langword="true"/>
+        /// </summary>
+        public bool OnlyAllowedScrap { get; set; } = true;
+        /// <summary>
+        /// Whether should <see cref="Value"/> be normalized using overtime bonus<br></br>
+        /// Default: <see langword="false"/>
+        /// </summary>
+        public bool WithOvertimeBonus { get; set; } = false;
+        /// <summary>
+        /// Whether should sell algorithms use only ship inventory items as <see cref="BaseScrapMatchAlgorithm.items"/><br></br>
+        /// Default: <see langword="false"/>
+        /// </summary>
+        public bool OnlyUseShipInventory { get; set; } = false;
+        /// <summary>
+        /// Algorithm to find correct scrap to fulfill the value<br></br>
+        /// Default: <see cref="DefaultScrapMatchAlgorithm"/>
+        /// </summary>
+        public BaseScrapMatchAlgorithm ScrapMatchAlgorithm { get; set; } = BaseScrapMatchAlgorithm.Default;
+
+        /// <summary>
+        /// Scrap value the player needs to get from current selling accounting <see cref="WithOvertimeBonus"/>
+        /// </summary>
+        public int TargetValue => WithOvertimeBonus ? GetSellValueWithOvertime() : GetSellValue(Value);
+
+        /// <summary>
+        /// Retrieves a match for <paramref name="items"/> to sell to fulfill <see cref="TargetValue"/>
+        /// </summary>
+        /// <param name="items"></param>
+        /// <returns></returns>
+        public ScrapToSell GetScrapToSell(List<ItemData> items)
+        {
+            if (Value == int.MaxValue)
+            {
+                return new ScrapToSell(items);
+            }
+
+            return new ScrapToSell(ScrapMatchAlgorithm.FindMatch(items, TargetValue, Plugin.ConfigManager.PrioritySellListArray));
+        }
+
+        private int GetSellValue(int value)
+        {
+            if (value == int.MaxValue) return value;
+            return Mathf.CeilToInt(Value / StartOfRound.Instance.companyBuyingRate);
+        }
+
+        private int GetSellValueWithOvertime()
+        {
+            int profitQuota = TimeOfDay.Instance.profitQuota;
+            int quotaFulfilled = TimeOfDay.Instance.quotaFulfilled;
+            int valueOver = quotaFulfilled + Value - profitQuota;
+            if (valueOver <= 0) return GetSellValue(Value);
+
+            int v = Value;
+            int profitQuotaLeft = Mathf.Max(profitQuota - quotaFulfilled, 0);
+            v -= (TimeOfDayPatch.GetDaysUntilDeadline() + 1) * 15;
+            int newValue = Mathf.CeilToInt((5 * v + profitQuotaLeft + 75) / 6f);
+
+            return GetSellValue(newValue);
+        }
+    }
+}

--- a/SellMyScrap/Data/SellCommandRequest.cs
+++ b/SellMyScrap/Data/SellCommandRequest.cs
@@ -57,7 +57,7 @@ namespace com.github.zehsteam.SellMyScrap.Data
         private int GetSellValue(int value)
         {
             if (value == int.MaxValue) return value;
-            return Mathf.CeilToInt(Value / StartOfRound.Instance.companyBuyingRate);
+            return Mathf.CeilToInt(value / StartOfRound.Instance.companyBuyingRate);
         }
 
         private int GetSellValueWithOvertime()

--- a/SellMyScrap/Helpers/ScrapMatchAlgorithms/BaseScrapMatchAlgorithm.cs
+++ b/SellMyScrap/Helpers/ScrapMatchAlgorithms/BaseScrapMatchAlgorithm.cs
@@ -1,0 +1,110 @@
+﻿using com.github.zehsteam.SellMyScrap.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace com.github.zehsteam.SellMyScrap.Helpers.ScrapMatchAlgorithms
+{
+    /// <summary>
+    /// Base abstract class for scrap match algorithms.
+    /// </summary>
+    public abstract class BaseScrapMatchAlgorithm
+    {
+        /// <summary>All items available to sell</summary>
+        protected List<ItemData> items;
+        /// <summary>Requested target value that must be fulfilled</summary>
+        protected int targetValue;
+        /// <summary>Priority scrap names <see cref="HashSet{T}"/> for quick case-insensitive lookups</summary>
+        protected HashSet<string> prioritySet;
+
+        /// <summary>
+        /// Checks for edge cases and uses an algorithm to find a suitable combination of scrap to fulfill <see cref="targetValue"/>.
+        /// </summary>
+        /// <returns>Scrap list to sell from given <see cref="items"/> to fulfill <see cref="targetValue"/>.</returns>
+        public List<ItemData> FindMatch(List<ItemData> items, int targetValue, string[] priorityList = null)
+        {
+            this.items = items;
+            this.targetValue = targetValue;
+            this.prioritySet = new HashSet<string>(priorityList ?? [], System.StringComparer.OrdinalIgnoreCase);
+
+            // Step 1: Handle edge cases
+            if (items.Count == 0 || targetValue == int.MaxValue)
+            {
+                return items;
+            }
+
+            // Step 2: Find the minimum scrapValue item
+            var minScrapItem = items.OrderBy(item => item.ScrapValue).First();
+
+            if (targetValue <= minScrapItem.ScrapValue)
+            {
+                return [minScrapItem];
+            }
+
+            // Step 3: Check if total scrapValue is less than targetValue
+            int totalScrapValue = items.Sum(item => item.ScrapValue);
+
+            if (totalScrapValue < targetValue)
+            {
+                return items;
+            }
+
+            // Step 4: Use algorithm logic to find the best match to return
+            return RunScrapMatchAlgorithm(totalScrapValue);
+        }
+
+        /// <summary>
+        /// Checks if given <paramref name="item"/> is contained inside of a <see cref="prioritySet"/> HashSet
+        /// </summary>
+        /// <param name="item">Scrap Item</param>
+        /// <returns><see langword="true"/> if <see cref="prioritySet"/> has <paramref name="item"/>; otherwise, <see langword="false"/></returns>
+        protected bool IsPriority(ItemData item) => prioritySet.Contains(item.ItemName);
+
+        /// <summary>
+        /// Flag in the terminal to activate this algorithm (ex: 'sell quota -a1', then this property should return '1'). 
+        /// </summary>
+        public abstract int FlagIndex { get; }
+
+        /// <summary>
+        /// Runs scrap match searching algorithm to find a suitable combination assuming that edge cases were already checked.
+        /// </summary>
+        /// <param name="totalScrapValue">Total scrap value on the ship</param>
+        /// <returns>Scrap list to sell from given <see cref="items"/> to fulfill <see cref="targetValue"/>.</returns>
+        protected abstract List<ItemData> RunScrapMatchAlgorithm(int totalScrapValue);
+
+        /// <param name="flagIndex">Flag (ex: 'sell quota -a1' => 1)</param>
+        /// <returns><see cref="BaseScrapMatchAlgorithm"/> for given <paramref name="flagIndex"/></returns>
+        public static BaseScrapMatchAlgorithm GetAlgorithmByFlag(int flagIndex)
+        {
+            // Get all types from current assembly
+            var assembly = Assembly.GetExecutingAssembly();
+            var assemblyTypes = assembly.GetTypes();
+
+            // Iterate every child of BaseScrapMatchAlgorithm
+            foreach (var scrapMatchAlgorithmType in assemblyTypes
+                .Where(typeof(BaseScrapMatchAlgorithm).IsAssignableFrom))
+            {
+                // Check for abstraction, should not attempt to instantiate abstract classes as it'll lead to an exception
+                if (scrapMatchAlgorithmType.IsAbstract) continue;
+
+                // Instantiate currently observed algorithm
+                var scrapMatchAlgorithmObject = (BaseScrapMatchAlgorithm)Activator.CreateInstance(scrapMatchAlgorithmType);
+
+                // If flag equals, return the algorithm
+                if (flagIndex == scrapMatchAlgorithmObject.FlagIndex)
+                {
+                    return scrapMatchAlgorithmObject;
+                }
+            }
+
+            // In case no algorithm was found by given flag the code returns the default one
+            return Default;
+        }
+
+        /// <summary>
+        /// Get default scrap match algorithm
+        /// </summary>
+        public static BaseScrapMatchAlgorithm Default => new DefaultScrapMatchAlgorithm();
+    }
+}

--- a/SellMyScrap/Helpers/ScrapMatchAlgorithms/BruteForceMatchAlgorithm.cs
+++ b/SellMyScrap/Helpers/ScrapMatchAlgorithms/BruteForceMatchAlgorithm.cs
@@ -1,0 +1,137 @@
+﻿using com.github.zehsteam.SellMyScrap.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace com.github.zehsteam.SellMyScrap.Helpers.ScrapMatchAlgorithms
+{
+    /// <summary>
+    /// Brute force algorithm to find first match of scrap that equals to <see cref="BaseScrapMatchAlgorithm.targetValue"/>.
+    /// Very unstable and this algorithm's speed can vary, but usually it's fast
+    /// </summary>
+    public class BruteForceMatchAlgorithm : BaseScrapMatchAlgorithm
+    {
+        /// <inheritdoc/>
+        public override int FlagIndex => 2;
+
+        /// <inheritdoc/>
+        protected override List<ItemData> RunScrapMatchAlgorithm(int totalScrapValue)
+        {
+            var itemsToSell = new List<ItemData>();
+            orderedItems = this.items
+                .OrderBy(IsPriority)
+                .ThenByDescending(i => i.ScrapValue)
+                .ToArray();
+            bestCombination = new ScrapCombination();
+
+            return RecursiveScrapSearch(bestCombination);
+        }
+
+        // This algorithm is an iterative function instead of simple recursion,
+        // since otherwise the game will run out of memory
+        private ScrapCombination RecursiveScrapSearch(ScrapCombination itemsToSell)
+        {
+            var lastIndex = 0;
+
+            while (itemsToSell.Count != 0 || lastIndex != orderedItems.Length - 1)
+            {
+                for (int i = lastIndex; i < orderedItems.Length; i++)
+                {
+                    var item = orderedItems[i];
+                    if (itemsToSell.TotalScrap + item.ScrapValue == targetValue)
+                    {
+                        itemsToSell.Add(item, i);
+                        bestCombination = itemsToSell;
+                        return itemsToSell;
+                    }
+                    else if (itemsToSell.TotalScrap + item.ScrapValue < targetValue)
+                    {
+                        itemsToSell.Add(item, i);
+                    }
+                    else itemsToSell.UpdateIfBetterWith(item);
+                }
+
+                // Compare current best combination with current recursive iteration's combination
+                bestCombination = bestCombination.SaveBest(itemsToSell);
+
+                // Since no equal combination (the one with total value == target value) was found,
+                // remove last item from current combination
+                lastIndex = itemsToSell.LastIndex + 1;
+                itemsToSell.RemoveLast();
+            }
+
+            // If after iterating every possible combination was not found the equal one,
+            // return combination with the closest value
+            return bestCombination;
+        }
+
+        private ItemData[] orderedItems;
+        private ScrapCombination bestCombination;
+
+        private class ScrapCombination
+        {
+            public ScrapCombination()
+            {
+            }
+
+            protected ScrapCombination(ScrapCombination other) : this()
+            {
+                TotalScrap = other.TotalScrap;
+                TheoreticalLastItem = other.TheoreticalLastItem;
+                Items = new List<ItemData>(other.Items);
+                Indeces = new List<int>(other.Indeces);
+            }
+
+            public int TotalScrap { get; private set; } = 0;
+            public ItemData TheoreticalLastItem { get; private set; }
+            public int TotalScrapWithLastItem => TotalScrap + (TheoreticalLastItem?.ScrapValue ?? 0);
+            public int LastIndex => Indeces[^1];
+            private List<ItemData> Items { get; } = [];
+            private List<int> Indeces { get; } = [];
+
+            public int Count => Items.Count;
+
+            public void Add(ItemData item, int itemIndex)
+            {
+                Items.Add(item);
+                Indeces.Add(itemIndex);
+                TotalScrap += item.ScrapValue;
+                TheoreticalLastItem = null;
+
+                Plugin.Logger.LogInfo("Picked indeces: " + string.Join(" ", Indeces));
+            }
+
+            public void RemoveLast()
+            {
+                var item = Items[^1];
+                Items.RemoveAt(Count - 1);
+                Indeces.RemoveAt(Indeces.Count - 1);
+                TotalScrap -= item.ScrapValue;
+                TheoreticalLastItem = null;
+            }
+
+            public void UpdateIfBetterWith(ItemData item)
+            {
+                if (TheoreticalLastItem is null || TheoreticalLastItem.ScrapValue > item.ScrapValue)
+                {
+                    TheoreticalLastItem = item;
+                }
+            }
+
+            public ScrapCombination SaveBest(ScrapCombination other)
+            {
+                return other.TotalScrapWithLastItem >= TotalScrapWithLastItem ?
+                    this :
+                    new ScrapCombination(other);
+            }
+
+            public static implicit operator List<ItemData>(ScrapCombination sc)
+            {
+                var list = new List<ItemData>(sc.Items);
+                if (sc.TheoreticalLastItem != null)
+                    list.Add(sc.TheoreticalLastItem);
+                return list;
+            }
+        }
+    }
+}

--- a/SellMyScrap/Helpers/ScrapMatchAlgorithms/BruteForceMatchAlgorithm.cs
+++ b/SellMyScrap/Helpers/ScrapMatchAlgorithms/BruteForceMatchAlgorithm.cs
@@ -97,8 +97,6 @@ namespace com.github.zehsteam.SellMyScrap.Helpers.ScrapMatchAlgorithms
                 Indeces.Add(itemIndex);
                 TotalScrap += item.ScrapValue;
                 TheoreticalLastItem = null;
-
-                Plugin.Logger.LogInfo("Picked indeces: " + string.Join(" ", Indeces));
             }
 
             public void RemoveLast()

--- a/SellMyScrap/Helpers/ScrapMatchAlgorithms/DefaultScrapMatchAlgorithm.cs
+++ b/SellMyScrap/Helpers/ScrapMatchAlgorithms/DefaultScrapMatchAlgorithm.cs
@@ -1,0 +1,77 @@
+﻿using com.github.zehsteam.SellMyScrap.Data;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace com.github.zehsteam.SellMyScrap.Helpers.ScrapMatchAlgorithms
+{
+    /// <summary>
+    /// Default OG algorithm to find the best match of scrap to sell
+    /// </summary>
+    public class DefaultScrapMatchAlgorithm : BaseScrapMatchAlgorithm
+    {
+        /// <inheritdoc/>
+        public override int FlagIndex => 1;
+
+        /// <inheritdoc/>
+        protected override List<ItemData> RunScrapMatchAlgorithm(int totalScrapValue)
+        {
+            // Step 1: Initialize DP structures with additional priority count tracking
+            int maxPossibleValue = totalScrapValue;
+            int[] dp = new int[maxPossibleValue + 1];
+            List<ItemData>[] dpItems = new List<ItemData>[maxPossibleValue + 1];
+            int[] dpPriorityCount = new int[maxPossibleValue + 1]; // Track priority item counts in the DP states
+
+            for (int i = 0; i <= maxPossibleValue; i++)
+            {
+                dp[i] = int.MaxValue;
+                dpItems[i] = new List<ItemData>();
+                dpPriorityCount[i] = 0;
+            }
+
+            dp[0] = 0; // Base case
+
+            foreach (var item in items)
+            {
+                bool isPriority = IsPriority(item);
+                int itemPriorityValue = isPriority ? 1 : 0;
+
+                for (int j = maxPossibleValue; j >= item.ScrapValue; j--)
+                {
+                    int remainingValue = j - item.ScrapValue;
+                    if (dp[remainingValue] != int.MaxValue)
+                    {
+                        int newScrapValue = dp[remainingValue] + item.ScrapValue;
+                        int newPriorityCount = dpPriorityCount[remainingValue] + itemPriorityValue;
+
+                        // Compare based on scrap value first, then prioritize count if values match
+                        if (newScrapValue < dp[j] || newScrapValue == dp[j] && newPriorityCount > dpPriorityCount[j])
+                        {
+                            dp[j] = newScrapValue;
+                            dpItems[j] = new List<ItemData>(dpItems[remainingValue]) { item };
+                            dpPriorityCount[j] = newPriorityCount;
+                        }
+                    }
+                }
+            }
+
+            // Step 2: Return the exact match if possible
+            if (dp[targetValue] != int.MaxValue)
+            {
+                return dpItems[targetValue];
+            }
+
+            // Step 3: If exact match is not possible, find the smallest valid over-target solution
+            for (int i = targetValue + 1; i <= maxPossibleValue; i++)
+            {
+                if (dp[i] != int.MaxValue)
+                {
+                    return dpItems[i];
+                }
+            }
+
+            // Fallback in case no valid set is found (should not happen in usual cases)
+            return items;
+        }
+    }
+}

--- a/SellMyScrap/Helpers/ScrapMatchAlgorithms/SuperFastScrapMatchAlgorithm.cs
+++ b/SellMyScrap/Helpers/ScrapMatchAlgorithms/SuperFastScrapMatchAlgorithm.cs
@@ -1,0 +1,45 @@
+﻿using com.github.zehsteam.SellMyScrap.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace com.github.zehsteam.SellMyScrap.Helpers.ScrapMatchAlgorithms
+{
+    /// <summary>
+    /// Super fast algorithm to find any match of scrap to sell that fulfills or exceeds the <see cref="BaseScrapMatchAlgorithm.targetValue"/>
+    /// </summary>
+    public class SuperFastScrapMatchAlgorithm : BaseScrapMatchAlgorithm
+    {
+        /// <inheritdoc/>
+        public override int FlagIndex => 3;
+
+        /// <inheritdoc/>
+        protected override List<ItemData> RunScrapMatchAlgorithm(int totalScrapValue)
+        {
+            var currentSellValue = 0;
+            var itemsToSell = new List<ItemData>();
+            var items = this.items.OrderBy(i => i.ItemName);
+
+            // Step 1: Calculate all priority scraps first
+            var priorityItems = items.Where(IsPriority).ToList();
+            AddToSellWhileNotFulfilled(priorityItems, ref currentSellValue, itemsToSell);
+
+            if (currentSellValue >= targetValue) return itemsToSell;
+                
+            // Step 2: Calculate other scraps if priority scrap wasn't enough
+            var otherItems = items.Except(priorityItems).ToList();
+            AddToSellWhileNotFulfilled(otherItems, ref currentSellValue, itemsToSell);
+
+            return itemsToSell;
+        }
+
+        private void AddToSellWhileNotFulfilled(List<ItemData> items, ref int currentSellValue, List<ItemData> itemsToSell)
+        {
+            for (int i = 0; i < items.Count && currentSellValue < targetValue; i++)
+            {
+                currentSellValue += items[i].ScrapValue;
+                itemsToSell.Add(items[i]);
+            }
+        }
+    }
+}

--- a/SellMyScrap/Plugin.cs
+++ b/SellMyScrap/Plugin.cs
@@ -5,6 +5,7 @@ using com.github.zehsteam.SellMyScrap.Data;
 using com.github.zehsteam.SellMyScrap.Dependencies;
 using com.github.zehsteam.SellMyScrap.Dependencies.ShipInventoryProxy;
 using com.github.zehsteam.SellMyScrap.Helpers;
+using com.github.zehsteam.SellMyScrap.Helpers.ScrapMatchAlgorithms;
 using com.github.zehsteam.SellMyScrap.MonoBehaviours;
 using com.github.zehsteam.SellMyScrap.Patches;
 using com.github.zehsteam.SellMyScrap.ScrapEaters;
@@ -122,9 +123,9 @@ internal class Plugin : BaseUnityPlugin
         CancelSellRequest();
     }
 
-    public ScrapToSell GetScrapToSell(int value, bool onlyAllowedScrap = true, bool withOvertimeBonus = false, bool onlyUseShipInventory = false)
+    public ScrapToSell GetScrapToSell(SellCommandRequest sellRequest)
     {
-        ScrapToSell = ScrapHelper.GetScrapToSell(value, onlyAllowedScrap, withOvertimeBonus, onlyUseShipInventory);
+        ScrapToSell = ScrapHelper.GetScrapToSell(sellRequest);
         return ScrapToSell;
     }
 


### PR DESCRIPTION
As I stated in issue #14, I needed more algorithms to speed up scrap combination search in lategame. This pull request provides my own solution to this issue.

With this PR, `sell amount` and `sell quota` will support algorithm flags, such as `sell quota -a:2`. Currently there are only three algorithms:
- DefaultScrapMatchAlgorithm (yours one) - **sell quota -a:1** or **sell quota** with no flags.
- BruteForceMatchAlgorithm (brute forces almost every possible combination until finds one using greedy algorithm) - **sell quota -a:2**
- SuperFastScrapMatchAlgorithm (finds absolutely any combination of scrap that fulfills or exceeds the quota) - **sell quota -a:3**

To implement a new algorithm you will need to create a class (preferably in Helpers.ScrapMatchAlgorithms folder), inherit `BaseScrapMatchAlgorithm` and implement abstract methods (give the algorithm a flag index (don't repeat it) and write your logic in abstract overriden method `RunScrapMatchAlgorithm(int totalScrapValue)`)

Tested this only in singleplayer yet, everything seems to work fine

You can request any changes, I'll do my best to fix everything!